### PR TITLE
maps are now externalized as a dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "leaflet.locatecontrol": "^0.42.0",
     "maxmind": "^0.5.5",
     "morgan": "^1.5.2",
+    "seattle-boundaries": "codeforseattle/seattle-boundaries",
     "sqlite3": "^3.0.5",
     "superagent-bluebird-promise": "^2.0.1",
     "topojson": "^1.6.19",


### PR DESCRIPTION
Seth and I have been working on a repo where Seattle maps are centrally collected. This project now uses that repo for its maps. Currently that means the maps for the Seattle City Council districts. Maps like US Census block groups will come out of there, moving forward.